### PR TITLE
Allow use of a custom Storage disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to `eloquentencryption` will be documented in this file
 
+## 3.1.0
+
+- Allow use of a custom Storage disk without extending RsaKeyStorageHandler class
+
 ## 3.0
 
 - As of **Laravel 8.14** you can specify the built in Eloquent Encryption casting setting a model's encryptUsing in your app service provider. This allows for automatic separation of your APP_KEY, when using a different `Illuminate\Contracts\Encryption\Encrypter` class/instance.
- 
+
 ```php
 EncryptedCast::encryptUsing(new \RichardStyles\EloquentEncryption\EloquentEncryption);
 ```
@@ -38,9 +42,9 @@ class EncryptedCast extends Model
 ## 1.3
 - bug fix
 
-## 1.2.0 
+## 1.2.0
 - Add additional Cast classes.
-- `EncryptedInteger` 
+- `EncryptedInteger`
 - `EncryptedFloat`
 - `EncryptedCollection`
 

--- a/config/eloquent_encryption.php
+++ b/config/eloquent_encryption.php
@@ -18,6 +18,11 @@ return [
         'store' => env('KEY_STORE', ''),
 
         /**
+         * A custom disk in Storage to be used. If null the default one is used.
+         */
+        'store_disk' => env('KEY_STORE_DISK'),
+
+        /**
          * The filename for the RSA public key
          */
         'public' => env('KEY_PUBLIC', 'eloquent_encryption.pub'),

--- a/src/FileSystem/RsaKeyStorageHandler.php
+++ b/src/FileSystem/RsaKeyStorageHandler.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace RichardStyles\EloquentEncryption\FileSystem;
-
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
@@ -11,6 +9,12 @@ use RichardStyles\EloquentEncryption\Exceptions\RSAKeyFileMissing;
 
 class RsaKeyStorageHandler implements RsaKeyHandler
 {
+    /**
+     * Application Storage instance
+     *
+     * @var Storage $storage
+     */
+    private $storage;
 
     /**
      * Storage path for the Public Key File
@@ -31,10 +35,13 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function __construct()
     {
-        $this->public_key_path =
-            Config::get('eloquent_encryption.key.public', 'eloquent_encryption.pub');
-        $this->private_key_path =
-            Config::get('eloquent_encryption.key.private', 'eloquent_encryption');
+        $config = config('eloquent_encryption.key');
+
+        $this->storage = $this->storage->disk($config['store_disk']);
+
+        $this->public_key_path = $config['public'];
+
+        $this->private_key_path = $config['private'];
     }
 
     /**
@@ -54,7 +61,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function hasPrivateKey()
     {
-        return Storage::exists($this->private_key_path);
+        return $this->storage->exists($this->private_key_path);
     }
 
     /**
@@ -64,7 +71,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function hasPublicKey()
     {
-        return Storage::exists($this->public_key_path);
+        return $this->storage->exists($this->public_key_path);
     }
 
     /**
@@ -75,8 +82,8 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function saveKey($public, $private)
     {
-        Storage::put($this->public_key_path, $public);
-        Storage::put($this->private_key_path, $private);
+        $this->storage->put($this->public_key_path, $public);
+        $this->storage->put($this->private_key_path, $private);
     }
 
     /**
@@ -91,7 +98,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
             throw new RSAKeyFileMissing();
         }
 
-        return Storage::get($this->public_key_path);
+        return $this->storage->get($this->public_key_path);
     }
 
     /**
@@ -106,6 +113,6 @@ class RsaKeyStorageHandler implements RsaKeyHandler
             throw new RSAKeyFileMissing();
         }
 
-        return Storage::get($this->private_key_path);
+        return $this->storage->get($this->private_key_path);
     }
 }


### PR DESCRIPTION
Main goal of this PR is to allow use of a custom Storage disk without extending RsaKeyStorageHandler class.

It add a new config value and use it in RsaKeyStorageHandler class if filled in instead of default Storage disk one.

Then this PR offers a small improvement in performance by loading the Storage and Config instances only once in RsaKeyStorageHandler constructor class.