### PR TITLE
Add customizable storage disk support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0",
         "illuminate/database": "^8.14",
         "phpseclib/phpseclib": "~2.0"

--- a/config/eloquent_encryption.php
+++ b/config/eloquent_encryption.php
@@ -12,10 +12,15 @@ return [
         'length' => env('KEY_LENGTH', 4096),
 
         /**
+         * A custom disk in Storage to be used. If null the default one is used.
+         */
+        'store_disk' => env('KEY_STORE_DISK'),
+
+        /**
          * The path in Storage where the keys should be saved.
          * DO NOT SET THIS UNDER app/public or anywhere publicly accessible.
          */
-        'store' => env('KEY_STORE', ''),
+        'store_path' => env('KEY_STORE_PATH', ''),
 
         /**
          * The filename for the RSA public key

--- a/src/EloquentEncryptionServiceProvider.php
+++ b/src/EloquentEncryptionServiceProvider.php
@@ -63,7 +63,7 @@ class EloquentEncryptionServiceProvider extends ServiceProvider
         });
 
         // Automatically apply the package configuration
-        $this->mergeConfigFrom(__DIR__ . '/../config/eloquent_encryption.php', 'eloquentencryption');
+        $this->mergeConfigFrom(__DIR__ . '/../config/eloquent_encryption.php', 'eloquent_encryption');
 
         // Register the main class to use with the facade
         $this->app->singleton('eloquentencryption', function () {

--- a/src/FileSystem/RsaKeyStorageHandler.php
+++ b/src/FileSystem/RsaKeyStorageHandler.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace RichardStyles\EloquentEncryption\FileSystem;
-
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
@@ -11,6 +9,12 @@ use RichardStyles\EloquentEncryption\Exceptions\RSAKeyFileMissing;
 
 class RsaKeyStorageHandler implements RsaKeyHandler
 {
+    /**
+     * Application Storage instance
+     *
+     * @var Storage $storage
+     */
+    private $storage;
 
     /**
      * Storage path for the Public Key File
@@ -31,10 +35,13 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function __construct()
     {
-        $this->public_key_path =
-            Config::get('eloquent_encryption.key.public', 'eloquent_encryption.pub');
-        $this->private_key_path =
-            Config::get('eloquent_encryption.key.private', 'eloquent_encryption');
+        $config = config('eloquent_encryption.key');
+
+        $this->storage = Storage::disk($config['store_disk']);
+
+        $this->public_key_path = trim($config['store_path'], '/').'/'.$config['public'];
+
+        $this->private_key_path = trim($config['store_path'], '/').'/'.$config['private'];
     }
 
     /**
@@ -54,7 +61,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function hasPrivateKey()
     {
-        return Storage::exists($this->private_key_path);
+        return $this->storage->exists($this->private_key_path);
     }
 
     /**
@@ -64,7 +71,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function hasPublicKey()
     {
-        return Storage::exists($this->public_key_path);
+        return $this->storage->exists($this->public_key_path);
     }
 
     /**
@@ -75,8 +82,8 @@ class RsaKeyStorageHandler implements RsaKeyHandler
      */
     public function saveKey($public, $private)
     {
-        Storage::put($this->public_key_path, $public);
-        Storage::put($this->private_key_path, $private);
+        $this->storage->put($this->public_key_path, $public);
+        $this->storage->put($this->private_key_path, $private);
     }
 
     /**
@@ -91,7 +98,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
             throw new RSAKeyFileMissing();
         }
 
-        return Storage::get($this->public_key_path);
+        return $this->storage->get($this->public_key_path);
     }
 
     /**
@@ -106,6 +113,6 @@ class RsaKeyStorageHandler implements RsaKeyHandler
             throw new RSAKeyFileMissing();
         }
 
-        return Storage::get($this->private_key_path);
+        return $this->storage->get($this->private_key_path);
     }
 }

--- a/src/FileSystem/RsaKeyStorageHandler.php
+++ b/src/FileSystem/RsaKeyStorageHandler.php
@@ -12,7 +12,7 @@ class RsaKeyStorageHandler implements RsaKeyHandler
     /**
      * Application Storage instance
      *
-     * @var Storage $storage
+     * @var Illuminate\Contracts\Filesystem\Filesystem $storage
      */
     private $storage;
 

--- a/tests/Traits/WithRSAHelpers.php
+++ b/tests/Traits/WithRSAHelpers.php
@@ -33,28 +33,33 @@ trait WithRSAHelpers
         Storage::assertExists($private);
     }
 
-    public function makePrivateKey()
+    public function makePrivateKey($path = '', $disk = null)
     {
         return $this->makeKey(
-            '',
-            'eloquent_encryption'
+            $path,
+            'eloquent_encryption',
+            $disk
         );
     }
 
-    public function makePublicKey()
+    public function makePublicKey($path = '', $disk = null)
     {
         return $this->makeKey(
-            '',
-            'eloquent_encryption.pub'
+            $path,
+            'eloquent_encryption.pub',
+            $disk
         );
     }
 
-    private function makeKey($path, $key)
+    private function makeKey($path, $key, $disk = null)
     {
         // create fake files to act as both the rsa keys
         $file = UploadedFile::fake()->create($key, 250);
 
-        Storage::put($path.$key, $file);
+        Storage::disk($disk)->put(
+            trim($path, '/').'/'.$key,
+            $file
+        );
 
         return $key;
     }

--- a/tests/Unit/GenerateRsaKeysCommandTest.php
+++ b/tests/Unit/GenerateRsaKeysCommandTest.php
@@ -57,8 +57,8 @@ class GenerateRsaKeysCommandTest extends TestCase
 
         $this->assertTrue(EloquentEncryptionFacade::exists());
 
-        $original_public = Storage::get(Config::get('eloquent_encryption.key.public', 'eloquent_encryption.pub'));
-        $original_private = Storage::get(Config::get('eloquent_encryption.key.public', 'eloquent_encryption'));
+        $original_public = Storage::get(Config::get('eloquent_encryption.key.public'));
+        $original_private = Storage::get(Config::get('eloquent_encryption.key.private'));
 
         $this->artisan('encrypt:generate')
             ->expectsOutput('Application RSA keys are already set')
@@ -69,8 +69,8 @@ class GenerateRsaKeysCommandTest extends TestCase
             ->expectsOutput('Creating RSA Keys for Application')
             ->assertExitCode(0);
 
-        $public = Storage::get(Config::get('eloquent_encryption.key.public', 'eloquent_encryption.pub'));
-        $private = Storage::get(Config::get('eloquent_encryption.key.public', 'eloquent_encryption'));
+        $public = Storage::get(Config::get('eloquent_encryption.key.public'));
+        $private = Storage::get(Config::get('eloquent_encryption.key.private'));
 
         $this->assertNotEquals($original_public, $public);
         $this->assertNotEquals($original_private, $private);

--- a/tests/Unit/StorageHandlerTest.php
+++ b/tests/Unit/StorageHandlerTest.php
@@ -3,6 +3,7 @@
 
 namespace RichardStyles\EloquentEncryption\Tests\Unit;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use RichardStyles\EloquentEncryption\Contracts\RsaKeyHandler;
 use RichardStyles\EloquentEncryption\EloquentEncryption;
@@ -75,5 +76,35 @@ class StorageHandlerTest extends TestCase
         $this->makePrivateKey();
 
         $this->assertTrue($this->handler->exists());
+    }
+
+    /** @test */
+    function storage_disk_can_be_customized_in_config()
+    {
+        $store_disk = 'test_disk';
+
+        Config::set(['eloquent_encryption.key.store_disk' => $store_disk]);
+        Storage::fake($store_disk);
+        
+        $handler = new RsaKeyStorageHandler();
+        
+        $this->makePrivateKey('', $store_disk);
+        $this->makePublicKey('', $store_disk);
+
+        $this->assertTrue($handler->exists());
+    }
+
+    /** @test */
+    function storage_path_can_be_customized_in_config()
+    {
+        $store_path = 'test_path/keys';
+        
+        Config::set(['eloquent_encryption.key.store_path' => $store_path]);
+        $handler = new RsaKeyStorageHandler();
+        
+        $this->makePrivateKey($store_path);
+        $this->makePublicKey($store_path);
+
+        $this->assertTrue($handler->exists());
     }
 }


### PR DESCRIPTION
This feature adds a configurable disk name for storage.

Idea and most work credits go to @forxer. I made a small change to make it actually work, and added test support.

In the process I also made the store path config variable work.