### PR TITLE
Add support for php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0",
         "illuminate/database": "^8.14",
         "phpseclib/phpseclib": "~2.0"


### PR DESCRIPTION
Run the ```composer test``` with the following result:
```bash
> vendor/bin/phpunit.bat
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.12
Configuration: D:\repos\GitHub\EloquentEncryption\phpunit.xml.dist
Error:         This version of PHPUnit does not support code coverage on PHP 8

....................................                              36 / 36 (100%)

Time: 3.34 seconds, Memory: 38.00 MB

OK (36 tests, 56 assertions)
```